### PR TITLE
Add Spring-Cloud-Gateway Route usages.

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -20,11 +20,14 @@ repositories {
 }
 
 extra["springCloudVersion"] = "2025.1.0-M3"
+extra["wireMockSpringBoot"] = "3.10.0"
 
 dependencies {
-	implementation("org.springframework.cloud:spring-cloud-starter-gateway-server-webmvc")
-	testImplementation("org.springframework.boot:spring-boot-starter-test")
-	testRuntimeOnly("org.junit.platform:junit-platform-launcher")
+    implementation("org.springframework.cloud:spring-cloud-starter-gateway-server-webmvc")
+    testImplementation("org.springframework.boot:spring-boot-starter-test")
+    testImplementation("org.wiremock.integrations:wiremock-spring-boot:${property("wireMockSpringBoot")}")
+    testImplementation("org.eclipse.jetty.ee10:jetty-ee10-bom:12.1.0") // https://github.com/wiremock/wiremock-spring-boot/issues/137
+    testRuntimeOnly("org.junit.platform:junit-platform-launcher")
 }
 
 dependencyManagement {

--- a/src/main/java/com/jiandong/gateway/RouteConfiguration.java
+++ b/src/main/java/com/jiandong/gateway/RouteConfiguration.java
@@ -1,0 +1,37 @@
+package com.jiandong.gateway;
+
+import org.springframework.cloud.gateway.server.mvc.filter.BeforeFilterFunctions;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.core.annotation.Order;
+import org.springframework.web.servlet.function.RouterFunction;
+import org.springframework.web.servlet.function.ServerResponse;
+
+import static org.springframework.cloud.gateway.server.mvc.handler.GatewayRouterFunctions.route;
+import static org.springframework.cloud.gateway.server.mvc.handler.HandlerFunctions.http;
+
+@Configuration
+public class RouteConfiguration {
+
+	@Bean
+	@Order(1)
+	RouterFunction<ServerResponse> routerFnRewritePath() {
+		return route("routerFnRewritePath")
+				.GET("/api/**", http())
+				.before(BeforeFilterFunctions.uri("http://localhost:8080"))
+				.before(BeforeFilterFunctions.rewritePath("/api", "/"))
+				.before(BeforeFilterFunctions.addRequestHeader("Authorization", "Basic dXNlcjp1c2VyX3B3ZA=="))
+				.build();
+	}
+
+	@Bean
+	@Order(2)
+	RouterFunction<ServerResponse> routerFnAddReqHeader() {
+		return route("routerFnAddReqHeader")
+				.GET("/**", http())
+				.before(BeforeFilterFunctions.uri("http://localhost:8080"))
+				.before(BeforeFilterFunctions.addRequestHeader("Authorization", "Basic dXNlcjp1c2VyX3B3ZA=="))
+				.build();
+	}
+
+}

--- a/src/main/java/com/jiandong/gateway/package-info.java
+++ b/src/main/java/com/jiandong/gateway/package-info.java
@@ -1,0 +1,2 @@
+@org.jspecify.annotations.NullMarked
+package com.jiandong.gateway;

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -1,3 +1,6 @@
+server:
+  port: 8090
+
 spring:
   application:
     name: spring-cloud-unknown

--- a/src/test/java/com/jiandong/ApplicationTests.java
+++ b/src/test/java/com/jiandong/ApplicationTests.java
@@ -1,8 +1,11 @@
 package com.jiandong;
 
+import org.junit.jupiter.api.Order;
 import org.junit.jupiter.api.Test;
+
 import org.springframework.boot.test.context.SpringBootTest;
 
+@Order(value = Integer.MAX_VALUE)
 @SpringBootTest
 class ApplicationTests {
 

--- a/src/test/java/com/jiandong/gateway/RouteConfigurationTest.java
+++ b/src/test/java/com/jiandong/gateway/RouteConfigurationTest.java
@@ -1,0 +1,74 @@
+package com.jiandong.gateway;
+
+import com.github.tomakehurst.wiremock.WireMockServer;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.wiremock.spring.ConfigureWireMock;
+import org.wiremock.spring.EnableWireMock;
+import org.wiremock.spring.InjectWireMock;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.annotation.DirtiesContext;
+import org.springframework.test.web.servlet.client.RestTestClient;
+
+import static com.github.tomakehurst.wiremock.client.WireMock.get;
+import static com.github.tomakehurst.wiremock.client.WireMock.ok;
+
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.DEFINED_PORT)
+@EnableWireMock(@ConfigureWireMock(port = 8080))
+@DirtiesContext
+class RouteConfigurationTest {
+
+	@Value("${server.port}")
+	int gatewayPort;
+
+	@InjectWireMock WireMockServer downStreamMockServer;
+
+	RestTestClient restTestClient;
+
+	@BeforeEach
+	void setUp() {
+		if (restTestClient == null) {
+			restTestClient = RestTestClient
+					.bindToServer()
+					.baseUrl("http://localhost:" + gatewayPort)
+					.build();
+		}
+	}
+
+	@Test
+	void testRouterFnRewritePath() {
+		// GIVEN a downstream mocked endpoint
+		downStreamMockServer.stubFor(get("/accounts").willReturn(ok("dummy account response")));
+
+		// WHEN send a request to gateway
+		// THEN gateway can return the response from the downstream endpoint
+		restTestClient.get()
+				.uri("/api/accounts")
+				.exchange()
+				.expectAll(responseSpec -> {
+					responseSpec.expectStatus().isOk();
+					responseSpec.expectBody(String.class)
+							.isEqualTo("dummy account response");
+				});
+	}
+
+	@Test
+	void testRouterFnAddReqHeader() {
+		// GIVEN a downstream mocked endpoint
+		downStreamMockServer.stubFor(get("/accounts").willReturn(ok("dummy account response")));
+
+		// WHEN send a request to gateway
+		// THEN gateway can return the response from the downstream endpoint
+		restTestClient.get()
+				.uri("/accounts")
+				.exchange()
+				.expectAll(responseSpec -> {
+					responseSpec.expectStatus().isOk();
+					responseSpec.expectBody(String.class)
+							.isEqualTo("dummy account response");
+				});
+	}
+
+}

--- a/src/test/resources/application.yml
+++ b/src/test/resources/application.yml
@@ -1,0 +1,2 @@
+server:
+  port: 8090

--- a/src/test/resources/junit-platform.properties
+++ b/src/test/resources/junit-platform.properties
@@ -1,0 +1,1 @@
+junit.jupiter.testclass.order.default=org.junit.jupiter.api.ClassOrderer$OrderAnnotation


### PR DESCRIPTION
Also, use WireMock to work as a downstream mock server, to test whole gateway integration flow.

more see: https://docs.spring.io/spring-cloud-gateway/reference/spring-cloud-gateway-server-webmvc/filters/addrequestheader.html