### PR TITLE
Spring cloud version upgrade

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -36,7 +36,7 @@ subprojects {
 
     dependencyManagement {
         imports {
-            mavenBom("org.springframework.cloud:spring-cloud-dependencies:2025.1.0-M4")
+            mavenBom("org.springframework.cloud:spring-cloud-dependencies:2025.1.0-RC1")
         }
     }
 


### PR DESCRIPTION
Since spring-cloud depends on spring-boot,  `dependabot` now raises 2 PRs for each version upgrade,  due to spring boot is a Major version this time, Unsurprisingly, both builds are failed.

this PR merged 2 commits and raising in a single one.